### PR TITLE
Fix bad zip downloads

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -43,7 +43,7 @@ def download_osmesa(retry_on_bad_zip=True):
             except Exception:
                 print "File not found, trying mirrors"
 
-    mesa_dir = os.path.join(context_dir,'OSMesa')
+    mesa_dir = os.path.join(context_dir, 'OSMesa')
     if not os.path.exists(mesa_dir):
         sysinfo = platform.uname()
         osmesa_fname = 'OSMesa.%s.%s.zip' % (sysinfo[0], sysinfo[-2])
@@ -65,7 +65,7 @@ def download_osmesa(retry_on_bad_zip=True):
 
 def autogen_opengl_sources():
     import os
-    sources = [ os.path.join(context_dir, x) for x in ['_constants.py', '_functions.pyx'] ]
+    sources = [ os.path.join(context_dir, x) for x in ['_constants.py', '_functions.pyx']]
     if not all([ os.path.exists(x) for x in sources ]):
         print "Autogenerating opengl sources"
         from contexts import autogen

--- a/utils.py
+++ b/utils.py
@@ -24,12 +24,13 @@ def wget(url, dest_fname=None):
         dest_fname = join(curdir, split(url)[1])
 
     try:
-        with urllib2.urlopen(url) as source:
-            with open(dest_fname, 'w') as f:
-                while True:
-                    contents = source.read(8000)
-                    if contents == "":
-                        break
-                    f.write(contents)
+        source = urllib2.urlopen(url)
+        with open(dest_fname, 'w') as f:
+            while True:
+                contents = source.read(8000)
+                if contents == "":
+                    break
+                f.write(contents)
+        source.close()
     except:
         raise Exception('Unable to get url: %s' % (url,))

--- a/utils.py
+++ b/utils.py
@@ -24,12 +24,12 @@ def wget(url, dest_fname=None):
         dest_fname = join(curdir, split(url)[1])
 
     try:
-        source = urllib2.urlopen(url)
-        with open(dest_fname, 'w') as f:
-            while True:
-                contents = source.read(8000)
-                if contents == "":
-                    break
-                f.write(contents)
+        with urllib2.urlopen(url) as source:
+            with open(dest_fname, 'w') as f:
+                while True:
+                    contents = source.read(8000)
+                    if contents == "":
+                        break
+                    f.write(contents)
     except:
         raise Exception('Unable to get url: %s' % (url,))


### PR DESCRIPTION
@mattloper, would you mind taking a quick look to confirm that this fix is acceptable?

I couldn't find you in Trello but here is the info on the ticket regarding this problem:

Installer currently uses urllib2 for fetching needed online resources. The needed resource is stored on s3 and is susceptible to the recent bad s3 reads without explicitly failing. When attempting to unzip the downloaded file, it fails.

Fix possibilities:

Test downloaded file's size against HTTP HEAD 'content-size'
Test downloaded file's MD5 checksum against recorded checksum
Catch BadZipError and have it repeat the download.
The first is the easiest but will only catch truncated file downloads and will only work if the remote server provides 'content-size'.

The second will also catch otherwise corrupted files but the correct checksum needs to be known, either hardcoded in the source code or exist as another file next to the file being downloaded.

Third possibility is also a pretty easy fix.

The wget command that does the urllib2 mediated download is only use two places: To download the installation zip file, and in util_tests.py where it fetches some public domain files from NASA.

Guillaume comment:
If all the files involved are zip files, then option #3 is better. Zip files include a size and CRC checksum in their table of content, and BadZipError are thrown when the sizes or the checksum checks fail. So options #1 and #2 would amount to implementing in-house functionality that is available off-the-shelf.

Since the wget function doesn't seem to be used very much in the first place and the bad downloads tend to be an s3 thing, I went with that implementation.