### PR TITLE
Unit test failure due to wrong dtype

### DIFF
--- a/test_renderer.py
+++ b/test_renderer.py
@@ -34,7 +34,7 @@ def getcam():
     w = 256
     h = 192
 
-    f = np.array([200,200])
+    f = np.array([200.,200.])
     rt = np.zeros(3)
     t = np.zeros(3)
     k = np.zeros(5)


### PR DESCRIPTION
I am not sure how this ever passed. Perhaps an earlier version of numpy transparently recast ints to floats?

@dlsmith @mattloper  - I think my fix is legit but I obviously don't have a ton of insight into opendr